### PR TITLE
[Fix] : 잘못된 페이지 라우팅 #34 - 잘못된 `/home` 이동 버그 해결

### DIFF
--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,3 +1,4 @@
 export const Home = () => {
+  console.log('Home');
   return <>Home</>;
 };

--- a/src/routes/PrivateRoute.tsx
+++ b/src/routes/PrivateRoute.tsx
@@ -1,5 +1,6 @@
 import { ROUTE_PATH } from '@/routes/ROUTE_PATH.ts';
 import { Navigate, Outlet, useMatches } from 'react-router-dom';
+import { normalizeUrlPath } from '@/utils/common';
 
 interface PrivateRouteProps {
   isAuthenticated: boolean;
@@ -7,7 +8,7 @@ interface PrivateRouteProps {
 
 export const PrivateRoute = ({ isAuthenticated }: PrivateRouteProps) => {
   const matches = useMatches();
-  const pathName = matches[1]['pathname'];
+  const pathName = normalizeUrlPath(matches[1]['pathname'], true);
   const param = matches[1]['params'];
 
   // Auth 완료
@@ -15,13 +16,15 @@ export const PrivateRoute = ({ isAuthenticated }: PrivateRouteProps) => {
     return <Navigate to={ROUTE_PATH.AUTH.LOGIN} replace />;
   }
 
-  // userId 가 필요한 도메인에 대해서 path 에 userId 가 없으면 자동으로 userId 를 할당시킴
-  if (isUserRequiredPath(pathName) && !param.userId) {
+  // userId 가 필요한 도메인에 대해서 userId 처리
+  if (isUserRequiredPath(pathName)) {
+    if (param.userId) return <Outlet />;
+
     const getUserId = 'empty';
     return <Navigate to={`${pathName}/${getUserId}`} replace />;
   }
 
-  // 그냥 id 가 없으면 404 페이지로 이동
+  // 도메인별 id 가 없으면 404 페이지로 이동
   if (!param.id) {
     return <Navigate to={'/notfound'} replace />;
   }
@@ -29,7 +32,7 @@ export const PrivateRoute = ({ isAuthenticated }: PrivateRouteProps) => {
   return <Outlet />;
 };
 
-const USER_REQUIRED_PATHS = ['/home'];
+const USER_REQUIRED_PATHS = [ROUTE_PATH.HOME.ROOT];
 
 const isUserRequiredPath = (path: string) => {
   return USER_REQUIRED_PATHS.some((requiredPath) => path.startsWith(requiredPath));

--- a/src/utils/common/index.ts
+++ b/src/utils/common/index.ts
@@ -1,0 +1,1 @@
+export { normalizeUrlPath } from './normalizePath';

--- a/src/utils/common/normalizePath.ts
+++ b/src/utils/common/normalizePath.ts
@@ -1,0 +1,22 @@
+/**
+ * URL 경로의 슬래시를 정규화하는 유틸리티 함수
+ * - 중복 슬래시 제거
+ * - 끝의 슬래시 제거 (옵션)
+ * - 시작은 항상 슬래시로 시작
+ */
+export function normalizeUrlPath(path: string, removeTrailingSlash: boolean = true): string {
+  // 1. 연속된 슬래시를 하나로 치환
+  let normalized = path.replace(/\/+/g, '/');
+
+  // 2. 시작이 슬래시가 아니면 추가
+  if (!normalized.startsWith('/')) {
+    normalized = '/' + normalized;
+  }
+
+  // 3. 끝의 슬래시 제거 (옵션)
+  if (removeTrailingSlash && normalized.length > 1 && normalized.endsWith('/')) {
+    normalized = normalized.slice(0, -1);
+  }
+
+  return normalized;
+}


### PR DESCRIPTION
1. Bug Fixes
- 중복 슬래시 처리 문제 해결 (/home/// -> /home)
- userId 파라미터 체크 로직 수정으로 무한 리다이렉션 버그 해결
- 경로 비교 시 정규화된 경로 사용하도록 수정

2. 버그 관련 추가 개선
- URL 경로 정규화 유틸리티 함수 추가 (normalizeUrlPath)
- `PrivateRoute` 의 경로 처리 로직 개선
- `USER_REQUIRED_PATHS` 에서 하드코딩된 경로를 상수로 변경