### PR TITLE
[Feat]: Line 엘리먼트 포인트 조작 기능 구현 #50

### DIFF
--- a/src/core/models/sketchElement/BaseSketchElement.ts
+++ b/src/core/models/sketchElement/BaseSketchElement.ts
@@ -60,6 +60,9 @@ export abstract class BaseSketchElement<T extends SketchElementType> {
     }
   }
 
+  // 모든 객체가 공통적으로 가지는 메서드
+  abstract draw(ctx: CanvasRenderingContext2D): void;
+
   _convertLinePoint(points: Point[]) {
     const convertIds: string[] = [];
     const convertPoint: Record<string, ElementPoint> = {};
@@ -73,9 +76,6 @@ export abstract class BaseSketchElement<T extends SketchElementType> {
       convertPoint,
     };
   }
-
-  // 모든 객체가 공통적으로 가지는 메서드
-  abstract draw(ctx: CanvasRenderingContext2D): void;
 
   // 이동(드래그) 시 위치 변경
   move(dx: number, dy: number) {

--- a/src/core/models/sketchElement/LineSketchElement.ts
+++ b/src/core/models/sketchElement/LineSketchElement.ts
@@ -1,5 +1,6 @@
 import { Point } from '@/shared/utils/collidingDetection';
 import { BaseSketchElement, BaseSketchElementParams } from '@/core/models/sketchElement/BaseSketchElement.ts';
+import { getArrayFirst, getArrayLast } from '@/shared/utils/common';
 
 export type LineType = 'line';
 
@@ -20,7 +21,6 @@ export class LineSketchElement extends BaseSketchElement<LineType> {
 
   constructor(props: LineSketchElementParams) {
     super(props);
-
     const { convertIds, convertPoint } = this._convertLinePoint(props.initPoints);
     this.points = convertPoint;
     this.pointIds = convertIds;
@@ -48,6 +48,49 @@ export class LineSketchElement extends BaseSketchElement<LineType> {
     });
     ctx.stroke();
     ctx.restore();
+  }
+
+  changePoint(dx: number, dy: number, directions: 'point-start' | 'point-end') {
+    const startPointId = getArrayFirst(this.pointIds);
+    const endPointId = getArrayLast(this.pointIds);
+
+    if (!startPointId || !endPointId) {
+      throw new Error('changePoint Error');
+    }
+
+    const startPoint = this.points[startPointId];
+    const endPoint = this.points[endPointId];
+
+    // 포인트 위치 업데이트
+    if (directions === 'point-start') {
+      this.points[startPointId] = {
+        ...startPoint,
+        x: startPoint.x + dx,
+        y: startPoint.y + dy,
+      };
+    } else {
+      this.points[endPointId] = {
+        ...endPoint,
+        x: endPoint.x + dx,
+        y: endPoint.y + dy,
+      };
+    }
+
+    // 업데이트된 포인트 가져오기
+    const updatedStartPoint = this.points[startPointId];
+    const updatedEndPoint = this.points[endPointId];
+
+    // 엘리먼트 크기 및 위치 계산
+    const minX = Math.min(updatedStartPoint.x, updatedEndPoint.x);
+    const maxX = Math.max(updatedStartPoint.x, updatedEndPoint.x);
+    const minY = Math.min(updatedStartPoint.y, updatedEndPoint.y);
+    const maxY = Math.max(updatedStartPoint.y, updatedEndPoint.y);
+
+    // 엘리먼트 속성 업데이트
+    this.width = maxX - minX;
+    this.height = maxY - minY;
+    this.x = minX + this.width / 2; // 중심점 X
+    this.y = minY + this.height / 2; // 중심점 Y
   }
 
   /**

--- a/src/core/models/sketchFile/type.ts
+++ b/src/core/models/sketchFile/type.ts
@@ -1,9 +1,8 @@
-import { EllipseSketchElement, RectSketchElement } from '@/core/models/sketchElement';
-import { LineSketchElement } from '@/core/models/sketchElement/LineSketchElement.ts';
+import { SketchElement } from '@/core/models/sketchElement';
 
 export interface ElementRegistry {
   elements: {
-    [id: string]: EllipseSketchElement | RectSketchElement | LineSketchElement;
+    [id: string]: SketchElement;
   };
   layerOrder: string[];
 }

--- a/src/features/sketch/SketchContextMenu.tsx
+++ b/src/features/sketch/SketchContextMenu.tsx
@@ -22,8 +22,10 @@ export const SketchContextMenu = ({ children, selectState, clipboardAction, dele
 
   const handleChangeMenu = useCallback(
     (event: any) => {
+      if (!selectState.boundingBox) return;
       const clientX = event.clientX;
       const clientY = event.clientY;
+
       if (isPointInAABB(selectState.boundingBox, { x: clientX, y: clientY })) {
         setMenuMode('selection');
       } else {

--- a/src/features/sketch/hooks/usePaintingSketch.ts
+++ b/src/features/sketch/hooks/usePaintingSketch.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { useEffect } from 'react';
 import { colorToken } from '@/shared/styles/color';
-import { SelectManagerState, ViewManagerState, CreateElementManagerState, CreateLineManagerState } from '@/features/sketch/hooks/index.ts';
 import { ElementRegistry } from '@/core/models/sketchFile';
+import { SelectManagerState, ViewManagerState, CreateElementManagerState, CreateLineManagerState } from '@/features/sketch/hooks/index.ts';
 
 /**
  * ### usePaintingSketch()
@@ -54,44 +54,67 @@ export function usePaintingSketch(
     ctx.restore();
 
     if (selectState.selectElements.length > 0) {
-      if (!selectState.boundingBox) return;
-
-      const { cx, cy, width, height } = selectState.boundingBox;
-
-      ctx.save();
       const resizeAnchorWidth = 8; // 앵커의 길이
       const resizeAnchorRadius = 2; // 모서리 반경 설정
-      const resizeAnchorPosition = [
-        { x: cx - width / 2, y: cy - height / 2 }, // 왼쪽 상단
-        { x: cx - width / 2, y: cy + height / 2 }, // 왼쪽 하단
-        { x: cx + width / 2, y: cy - height / 2 }, // 오른쪽 상단
-        { x: cx + width / 2, y: cy + height / 2 }, // 오른쪽 하단
-      ];
 
-      // 스타일 적용
-      ctx.lineWidth = 2;
-      ctx.strokeStyle = colorToken['focusColor'];
-      ctx.fillStyle = 'transparent';
+      if (selectState.boundingBox) {
+        const { cx, cy, width, height } = selectState.boundingBox;
 
-      // 사각형 그리기
-      ctx.beginPath(); // 다른 도형들과 분리되어 독립적으로 처리
-      ctx.rect(cx - width / 2, cy - height / 2, width, height);
-      ctx.fill();
-      ctx.stroke();
-      ctx.closePath();
+        ctx.save();
+        const resizeAnchorPosition = [
+          { x: cx - width / 2, y: cy - height / 2 }, // 왼쪽 상단
+          { x: cx - width / 2, y: cy + height / 2 }, // 왼쪽 하단
+          { x: cx + width / 2, y: cy - height / 2 }, // 오른쪽 상단
+          { x: cx + width / 2, y: cy + height / 2 }, // 오른쪽 하단
+        ];
 
-      // 앵커 사각형 그리기
-      for (const anchorPosition of resizeAnchorPosition) {
-        const { x, y } = anchorPosition;
-        ctx.lineWidth = 3;
+        // 스타일 적용
+        ctx.lineWidth = 2;
         ctx.strokeStyle = colorToken['focusColor'];
-        ctx.fillStyle = colorToken['white'];
+        ctx.fillStyle = 'transparent';
 
-        ctx.beginPath();
-        ctx.roundRect(x - resizeAnchorWidth / 2, y - resizeAnchorWidth / 2, resizeAnchorWidth, resizeAnchorWidth, resizeAnchorRadius);
-        ctx.stroke();
+        // 사각형 그리기
+        ctx.beginPath(); // 다른 도형들과 분리되어 독립적으로 처리
+        ctx.rect(cx - width / 2, cy - height / 2, width, height);
         ctx.fill();
+        ctx.stroke();
+        ctx.closePath();
+
+        // 앵커 사각형 그리기
+        for (const anchorPosition of resizeAnchorPosition) {
+          const { x, y } = anchorPosition;
+          ctx.lineWidth = 3;
+          ctx.strokeStyle = colorToken['focusColor'];
+          ctx.fillStyle = colorToken['white'];
+
+          ctx.beginPath();
+          ctx.roundRect(x - resizeAnchorWidth / 2, y - resizeAnchorWidth / 2, resizeAnchorWidth, resizeAnchorWidth, resizeAnchorRadius);
+          ctx.stroke();
+          ctx.fill();
+        }
       }
+
+      // boundingLine 그리기
+      if (selectState.boundingLine) {
+        const boundingLineValue = [selectState.boundingLine.startPoint, selectState.boundingLine.endPoint];
+
+        for (const point of boundingLineValue) {
+          ctx.lineWidth = 3;
+          ctx.strokeStyle = colorToken['focusColor'];
+          ctx.fillStyle = colorToken['white'];
+          ctx.beginPath();
+          ctx.roundRect(
+            point.x - resizeAnchorWidth / 2,
+            point.y - resizeAnchorWidth / 2,
+            resizeAnchorWidth,
+            resizeAnchorWidth,
+            resizeAnchorRadius,
+          );
+          ctx.stroke();
+          ctx.fill();
+        }
+      }
+
       ctx.restore();
     }
 

--- a/src/features/sketch/hooks/useSketchElementRegistry.ts
+++ b/src/features/sketch/hooks/useSketchElementRegistry.ts
@@ -6,6 +6,7 @@ import { useSketchFilesRegistry } from '@/features/sketchFiles/hooks';
 import { CanvasRegistryState, ElementRegistry, resetSketchFile } from '@/core/models/sketchFile';
 import {
   FactorySketchElement,
+  LineSketchElement,
   SketchElement,
   SketchElementParams,
   SketchElementStyle,
@@ -19,6 +20,12 @@ interface ResizeParams {
   pointDirection: ('right' | 'left' | 'top' | 'bottom')[];
 }
 
+interface PointParams {
+  dx: number;
+  dy: number;
+  pointDirection: 'point-start' | 'point-end';
+}
+
 interface MoveParams {
   moveX: number;
   moveY: number;
@@ -27,8 +34,9 @@ interface MoveParams {
 export interface ElementRegistryAction {
   createElements: <T extends SketchElementType>(params: SketchElementParams<T>[]) => void;
   pasteElements: <T extends SketchElementType>(params: SketchElement<T>[]) => void;
-  createSingleElement: <T extends SketchElementType>(params: SketchElementParams<T>) => void;
   deleteElements: (ids: string[]) => void;
+  createSingleElement: <T extends SketchElementType>(params: SketchElementParams<T>) => void;
+  moveLinePoint: (id: string, transformParam: PointParams) => void;
   moveElement: (id: string, transformParam: MoveParams) => void;
   resizeElement: (id: string, transformParam: ResizeParams) => void;
   updateStyleElement: (id: string, transformParam: SketchElementStyle) => void;
@@ -168,6 +176,22 @@ export function useSketchElementRegistry(): {
     }));
   };
 
+  const moveLinePoint = (id: string, params: PointParams) => {
+    const updateElement = elementRegistry.elements[id];
+    const updateElements = { ...elementRegistry.elements };
+    if (updateElement instanceof LineSketchElement) {
+      updateElement.changePoint(params.dx, params.dy, params.pointDirection);
+      updateElements[id] = updateElement;
+    }
+    setElementRegistry((prev) => ({
+      ...prev,
+      elementRegistry: {
+        elements: updateElements,
+        layerOrder: prev.elementRegistry.layerOrder,
+      },
+    }));
+  };
+
   const resizeElement = (id: string, params: ResizeParams) => {
     const updateElement = elementRegistry.elements[id];
     const updateElements = { ...elementRegistry.elements };
@@ -210,6 +234,7 @@ export function useSketchElementRegistry(): {
       moveElement,
       resizeElement,
       updateStyleElement,
+      moveLinePoint,
     },
   };
 }

--- a/src/features/sketch/utils/convertSelectLine.ts
+++ b/src/features/sketch/utils/convertSelectLine.ts
@@ -1,0 +1,61 @@
+import { getArrayFirst, getArrayLast, OnlyClassProperties } from '@/shared/utils/common';
+import { SketchElement } from '@/core/models/sketchElement';
+import { Point } from '@/shared/utils/collidingDetection';
+import { ViewState } from '@/core/stores';
+import { LineType } from '@/core/models/sketchElement/LineSketchElement.ts';
+
+export interface BoundingLine {
+  startPoint: Point;
+  endPoint: Point;
+  cx: number;
+  cy: number;
+  rotation: number;
+  length: number;
+}
+
+export function convertSelectLine(
+  lineElement: OnlyClassProperties<SketchElement<LineType>>,
+  viewState: ViewState,
+): BoundingLine | undefined {
+  if (lineElement.pointIds.length < 2) {
+    console.error('잘못된 line Element');
+    return;
+  }
+  const scale = viewState.scale;
+  const offsetX = viewState.offset.x;
+  const offsetY = viewState.offset.y;
+  const convertPoint: Point[] = lineElement.pointIds.map((pointId) => {
+    const pointInfo = lineElement.points[pointId];
+    const viewX = offsetX + scale * pointInfo.x;
+    const viewY = offsetY + scale * pointInfo.y;
+    return {
+      x: viewX,
+      y: viewY,
+    };
+  });
+
+  const startPoint = getArrayFirst(convertPoint);
+  const endPoint = getArrayLast(convertPoint);
+  if (!startPoint || !endPoint) {
+    throw new Error('convertSelectLine Error : 잘못된 시작점 혹은 끝점의 값');
+  }
+
+  // 중심점 계산
+  const dx = endPoint.x - startPoint.x;
+  const dy = endPoint.y - startPoint.y;
+  const cx = (startPoint.x + endPoint.x) / 2;
+  const cy = (startPoint.y + endPoint.y) / 2;
+  const length = Math.sqrt(dx * dx + dy * dy);
+
+  // 각도 계산 (라디안) Math.atan2는 -π에서 π 사이의 값을 반환
+  const rotation = Math.atan2(dy, dx);
+
+  return {
+    startPoint: startPoint,
+    endPoint: endPoint,
+    cx,
+    cy,
+    rotation,
+    length,
+  };
+}

--- a/src/features/sketch/utils/index.ts
+++ b/src/features/sketch/utils/index.ts
@@ -1,2 +1,5 @@
 export { convertSelectBoxList } from './convertSelectBoxList';
+export { convertSelectLine } from './convertSelectLine';
+export type { BoundingLine } from './convertSelectLine';
+
 export { isShapeType, isLineType } from './validateShapeType';

--- a/src/shared/utils/common/array.ts
+++ b/src/shared/utils/common/array.ts
@@ -1,0 +1,7 @@
+export function getArrayFirst<T>(arr: T[]): T | undefined {
+  return arr.length > 0 ? arr[0] : undefined;
+}
+
+export function getArrayLast<T>(arr: T[]): T | undefined {
+  return arr.length > 0 ? arr[arr.length - 1] : undefined;
+}

--- a/src/shared/utils/common/index.ts
+++ b/src/shared/utils/common/index.ts
@@ -1,5 +1,6 @@
 export { cn } from './cn.ts';
 export { normalizeUrlPath } from './normalizePath.ts';
 export { getRandomColor } from './getRandomColor.ts';
+export { getArrayFirst, getArrayLast } from './array.ts';
 
 export type { OnlyClassMethods, OnlyClassProperties } from './utilityTypes.ts';


### PR DESCRIPTION
1. Line 엘리먼트 기능 개선
   - `LineSketchElement.changePoint`메서드 구현: 포인트 위치 변경 시 엘리먼트 속성 자동 업데이트
   - 포인트 변경 시 width, height, 중심점(x, y) 자동 계산 로직 추가

2. 리사이즈 관리자 개선
   - ResizeHandlePosition 타입에 'point-start', 'point-end' 추가
   - getChangePointAtHandlePosition 함수 구현
   - Line 엘리먼트 포인트 조작을 위한 핸들러 추가

3. 선택 관리자 개선
   - BoundingLine 상태 추가 및 관리
   - Line 엘리먼트 선택 시 전용 UI 표시 로직 구현

4. Line Element 핸들러 표시
   - Line 엘리먼트 선택 시 시작점과 끝점에 조작 핸들 표시
   - 포인트 조작 UI 스타일링 적용

5. 타입 시스템 개선
   - ElementRegistry 타입 통합
   - BoundingLine 인터페이스 추가

### 추후 해야 할 것
- [ ] Line 선택에 대한 알고리즘 개선하기
- [ ] 단일 Line 이동에 대한 알고리즘 개선하기